### PR TITLE
Support multiple service versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,21 +7,43 @@ It proxies all requests to the host Wayland compositor using the virtwl Linux mo
 See https://alyssa.is/using-virtio-wl/ for some background.
 
 Since regular guest memory cannot be shared with the host, it allocates a shadow buffer from the host and copies the frame data into that.
-Wayland can also use graphics memory directly, which should avoid the copy.
-
-`tests/test.ml` is a simple test application that uses the virtwl kernel interface directly (without the proxy), avoiding any copying.
+Wayland can also use graphics memory directly, which should avoid the copy, but this is not yet supported.
 
 It can also be used to make changes to the protocol messages.
 e.g. using `--tag` will add a prefix to window titles.
 
 It is similar to the [sommelier][] proxy from ChromiumOS, but written in OCaml.
+It adds support for the primary selection, and aims to be easier to modify and less segfaulty.
 It uses the [ocaml-wayland][] library.
+
+It is able to proxy Evince and Firefox at least.
+
+## Installation
+
+I use the following systemd file to run it
+(in `~/.local/share/systemd/user/wayland-virtlw-proxy.service`):
+
+```
+[Unit]
+Description=Wayland-virtwl-proxy
+
+[Service]
+ExecStart=/path/to/wayland-proxy-virtwl --tag="[my-vm] " --wayland-display wayland-0
+
+[Install]
+WantedBy=default.target
+```
+
+## Using virtwl directly
+
+`tests/test.ml` is a simple test application that uses the virtwl kernel interface directly
+(without the proxy), avoiding any copying.
 
 ## TODO
 
-So far, it has only been tested with `evince` (GNOME's PDF viewer) and provides only the exact protocol versions that it requires. Also:
-
 - Find alternative to private `caml_unix_mapped_alloc`.
+- Only copy the buffer regions that have changed.
+- Fork a subprocess for each connection, like sommelier.
 
 [sommelier]: https://chromium.googlesource.com/chromiumos/platform2/+/main/vm_tools/sommelier/
 [ocaml-wayland]: https://github.com/talex5/ocaml-wayland

--- a/relay.ml
+++ b/relay.ml
@@ -23,40 +23,42 @@ type t = {
   host_registry : Wayland.Registry.t;
 }
 
-(* Data attached to host objects (e.g. the corresponding client object). *)
+(* Data attached to host objects (e.g. the corresponding client object).
+   Host and client versions are assumed to match. *)
 module HD = struct
   type 'a t = 
-    | Surface        : [`V3] C.Wl_surface.t                   -> [`Wl_surface]                  t
-    | Data_offer     : [`V3] C.Wl_data_offer.t                -> [`Wl_data_offer]               t
-    | Gtk_data_offer : [`V1] C.Gtk_primary_selection_offer.t  -> [`Gtk_primary_selection_offer] t
-    | Output         : [`V1] C.Wl_output.t                    -> [`Wl_output]                   t
+    | Surface        : 'v C.Wl_surface.t                   -> [`Wl_surface]                  t
+    | Data_offer     : 'v C.Wl_data_offer.t                -> [`Wl_data_offer]               t
+    | Gtk_data_offer : 'v C.Gtk_primary_selection_offer.t  -> [`Gtk_primary_selection_offer] t
+    | Output         : 'v C.Wl_output.t                    -> [`Wl_output]                   t
 end
 
-(* Data attached to client objects (e.g. the corresponding host object). *)
+(* Data attached to client objects (e.g. the corresponding host object).
+   Host and client versions are assumed to match. *)
 module CD = struct
-  type buffer = {
-    host_buffer : [`V1] H.Wl_buffer.t;
+  type 'v buffer = {
+    host_buffer : 'v H.Wl_buffer.t;
     host_memory : Cstruct.t;
     client_memory : Cstruct.t;
   }
 
-  type surface = {
-    host_surface : [`V3] H.Wl_surface.t;
+  type 'v surface = {
+    host_surface : 'v H.Wl_surface.t;
     mutable host_memory : Cstruct.t;
     mutable client_memory : Cstruct.t;
   }
 
   type 'a t = 
-    | Region           : [`V3] H.Wl_region.t                    -> [`Wl_region]                    t
-    | Surface          : surface                                -> [`Wl_surface]                   t
-    | Buffer           : buffer                                 -> [`Wl_buffer]                    t
-    | Seat             : [`V5] H.Wl_seat.t                      -> [`Wl_seat]                      t
-    | Output           : [`V2] H.Wl_output.t                    -> [`Wl_output]                    t
-    | Toplevel         : [`V1] H.Xdg_toplevel.t                 -> [`Xdg_toplevel]                 t
-    | Xdg_surface      : [`V1] H.Xdg_surface.t                  -> [`Xdg_surface]                  t
-    | Xdg_positioner   : [`V1] H.Xdg_positioner.t               -> [`Xdg_positioner]               t
-    | Data_source      : [`V3] H.Wl_data_source.t               -> [`Wl_data_source]               t
-    | Gtk_source       : [`V1] H.Gtk_primary_selection_source.t -> [`Gtk_primary_selection_source] t
+    | Region           : 'v H.Wl_region.t                    -> [`Wl_region]                    t
+    | Surface          : 'v surface                          -> [`Wl_surface]                   t
+    | Buffer           : 'v buffer                           -> [`Wl_buffer]                    t
+    | Seat             : 'v H.Wl_seat.t                      -> [`Wl_seat]                      t
+    | Output           : 'v H.Wl_output.t                    -> [`Wl_output]                    t
+    | Toplevel         : 'v H.Xdg_toplevel.t                 -> [`Xdg_toplevel]                 t
+    | Xdg_surface      : 'v H.Xdg_surface.t                  -> [`Xdg_surface]                  t
+    | Xdg_positioner   : 'v H.Xdg_positioner.t               -> [`Xdg_positioner]               t
+    | Data_source      : 'v H.Wl_data_source.t               -> [`Wl_data_source]               t
+    | Gtk_source       : 'v H.Gtk_primary_selection_source.t -> [`Gtk_primary_selection_source] t
 end
 
 (* Note: the role here is our role: [`Server] data is attached to proxies to

--- a/relay.ml
+++ b/relay.ml
@@ -1,5 +1,19 @@
+(* Relay Wayland messages between a client and a virtwl host compositor.
+   When sending a file descriptor, we create a virtwl descriptor of the appropriate type and send that instead.
+   For streams, we copy the data.
+   For buffers we copy the contents when the surface is committed (todo: copy just the damaged region).
+   We generally ignore the version part of the ocaml-wayland types and just cast as necessary.
+   Since we're relaying, we know that both sides are using the same version, so if we get e.g. a
+   version 5 request from the client then we know it's safe to send it to the host. *)
+
 open Lwt.Syntax
 open Wayland
+
+(* Since we're just relaying messages, we mostly don't care about checking version compatibility.
+   e.g. if a client sends us a v5 message, then we can assume the corresponding server object
+   supports v5 too (otherwise the client shouldn't have sent it).
+   So we just cast away version contraints using [cv]. *)
+let cv = Proxy.cast_version
 
 (* Modules we use to interact with the host (to which we are a client). *)
 module H = struct
@@ -111,24 +125,31 @@ let delete_with fn host client =
   fn host
 
 let make_region ~host_region r =
-  let h = host_region @@ H.Wl_region.v3 () in
+  let h = host_region @@ new H.Wl_region.handlers in
   let user_data = client_data (Region h) in
-  Proxy.Handler.attach r @@ C.Wl_region.v3 ~user_data @@ object
+  Proxy.Handler.attach r @@ object
+    inherit [_] C.Wl_region.handlers
+    method! user_data = user_data
     method on_add _ = H.Wl_region.add h
     method on_subtract _ = H.Wl_region.subtract h
     method on_destroy = delete_with H.Wl_region.destroy h
   end
 
-let make_surface ~host_surface _t c =
+let make_surface ~host_surface c =
   let h =
     let user_data = host_data (HD.Surface c) in
-    host_surface @@ H.Wl_surface.v3 ~user_data @@ object (_ : _ H.Wl_surface.h3)
+    host_surface @@ object
+      inherit [_] H.Wl_surface.handlers
+      method! user_data = user_data
       method on_enter _ ~output = C.Wl_surface.enter c ~output:(to_client output)
       method on_leave _ ~output = C.Wl_surface.leave c ~output:(to_client output)
     end
   in
+  let h = Proxy.cast_version h in
   let data = { CD.host_surface = h; host_memory = Cstruct.empty; client_memory = Cstruct.empty } in
-  Proxy.Handler.attach c @@ C.Wl_surface.v3 ~user_data:(client_data (Surface data)) @@ object (_ : 'a C.Wl_surface.h3)
+  Proxy.Handler.attach c @@ object
+    inherit [_] C.Wl_surface.handlers
+    method! user_data = client_data (Surface data)
     method on_attach _ ~buffer ~x ~y =
       match buffer with
       | Some buffer ->
@@ -145,32 +166,32 @@ let make_surface ~host_surface _t c =
       Cstruct.blit data.client_memory 0 data.host_memory 0 (Cstruct.len data.client_memory);
       H.Wl_surface.commit h
     method on_damage _ ~x ~y ~width ~height = H.Wl_surface.damage h ~x ~y ~width ~height
-    (*       method on_damage_buffer _ ~x ~y ~width ~height = H.Wl_surface.damage_buffer h ~x ~y ~width ~height *)
+    method on_damage_buffer _ ~x ~y ~width ~height = H.Wl_surface.damage_buffer h ~x ~y ~width ~height
     method on_destroy = delete_with H.Wl_surface.destroy h
     method on_frame _ callback =
       let _ : _ Proxy.t = H.Wl_surface.frame h @@ Wayland.callback @@ fun callback_data ->
         C.Wl_callback.done_ callback ~callback_data;
         Proxy.delete callback
       in
-      Proxy.Handler.attach callback @@ C.Wl_callback.v1 ()
+      Proxy.Handler.attach callback @@ new C.Wl_callback.handlers
     method on_set_input_region _ ~region = H.Wl_surface.set_input_region h ~region:(Option.map to_host region)
     method on_set_opaque_region _ ~region = H.Wl_surface.set_opaque_region h ~region:(Option.map to_host region)
     method on_set_buffer_scale _ = H.Wl_surface.set_buffer_scale h
     method on_set_buffer_transform _ = H.Wl_surface.set_buffer_transform h
   end
 
-let make_compositor t bind proxy =
-  let h = bind @@ H.Wl_compositor.v3 () in
-  let _ : _ Proxy.t = Proxy.Service_handler.attach proxy @@ C.Wl_compositor.v3 @@ object
-      method on_create_region _ = make_region ~host_region:(H.Wl_compositor.create_region h)
-      method on_create_surface _ = make_surface t ~host_surface:(H.Wl_compositor.create_surface h)
-    end
-  in
-  ()
+let make_compositor bind proxy =
+  let h = bind @@ new H.Wl_compositor.v1 in
+  Proxy.Handler.attach proxy @@ object
+    inherit [_] C.Wl_compositor.handlers
+    method on_create_region _ = make_region ~host_region:(H.Wl_compositor.create_region h)
+    method on_create_surface _ = make_surface ~host_surface:(H.Wl_compositor.create_surface h)
+  end
 
 let make_subsurface ~host_subsurface c =
-  let h = host_subsurface @@ H.Wl_subsurface.v1 () in
-  Proxy.Handler.attach c @@ C.Wl_subsurface.v1 @@ object (_ : 'a C.Wl_subsurface.h1)
+  let h = host_subsurface @@ new H.Wl_subsurface.handlers in
+  Proxy.Handler.attach c @@ object
+    inherit [_] C.Wl_subsurface.handlers
     method on_destroy = delete_with H.Wl_subsurface.destroy h
     method on_place_above _ ~sibling = H.Wl_subsurface.place_above h ~sibling:(to_host sibling)
     method on_place_below _ ~sibling = H.Wl_subsurface.place_below h ~sibling:(to_host sibling)
@@ -180,22 +201,23 @@ let make_subsurface ~host_subsurface c =
   end
 
 let make_subcompositor bind proxy =
-  let h = bind @@ H.Wl_subcompositor.v1 () in
-  let _ : _ Proxy.t = Proxy.Service_handler.attach proxy @@ C.Wl_subcompositor.v1 @@ object
-      method on_destroy = delete_with H.Wl_subcompositor.destroy h
+  let h = bind @@ new H.Wl_subcompositor.v1 in
+  Proxy.Handler.attach proxy @@ object
+    inherit [_] C.Wl_subcompositor.handlers
+    method on_destroy = delete_with H.Wl_subcompositor.destroy h
 
-      method on_get_subsurface _ subsurface ~surface ~parent =
-        let surface = to_host surface in
-        let parent = to_host parent in
-        let host_subsurface = H.Wl_subcompositor.get_subsurface h ~surface ~parent in
-        make_subsurface ~host_subsurface subsurface
-    end
-  in
-  ()
+    method on_get_subsurface _ subsurface ~surface ~parent =
+      let surface = to_host surface in
+      let parent = to_host parent in
+      let host_subsurface = H.Wl_subcompositor.get_subsurface h ~surface ~parent in
+      make_subsurface ~host_subsurface subsurface
+  end
 
 let make_buffer ~host_buffer ~host_memory ~client_memory proxy =
   let user_data = client_data (Buffer {host_buffer; host_memory; client_memory}) in
-  Proxy.Handler.attach proxy @@ C.Wl_buffer.v1 ~user_data @@ object
+  Proxy.Handler.attach proxy @@ object
+    inherit [_] C.Wl_buffer.handlers
+    method! user_data = user_data
     method on_destroy = delete_with H.Wl_buffer.destroy host_buffer
   end
 
@@ -212,7 +234,7 @@ let make_shm_pool ~virtwl ~host_shm proxy ~fd:client_fd ~size:orig_size =
     let client_memory_pool = Unix.map_file client_fd Bigarray.Char Bigarray.c_layout true [| Int32.to_int size |] in
     let host_pool, host_memory_pool =
       Wayland_virtwl.with_memory_fd virtwl ~size:(Int32.to_int size) (fun fd ->
-          let host_pool = H.Wl_shm.create_pool host_shm ~fd ~size @@ H.Wl_shm_pool.v1 () in
+          let host_pool = H.Wl_shm.create_pool host_shm ~fd ~size @@ new H.Wl_shm_pool.handlers in
           let host_memory = Wayland_virtwl.map_file fd Bigarray.Char ~n_elements:(Int32.to_int size) in
           host_pool, host_memory
         )
@@ -222,14 +244,17 @@ let make_shm_pool ~virtwl ~host_shm proxy ~fd:client_fd ~size:orig_size =
     { host_pool; client_memory_pool; host_memory_pool }
   in
   let mapping = ref (alloc ~size:orig_size) in
-  Proxy.Handler.attach proxy @@ C.Wl_shm_pool.v1 @@ object
+  Proxy.Handler.attach proxy @@ object
+    inherit [_] C.Wl_shm_pool.handlers
+
     method on_create_buffer _ buffer ~offset ~width ~height ~stride ~format =
       let len = Int32.to_int height * Int32.to_int stride in
       let host_memory = Cstruct.of_bigarray (!mapping).host_memory_pool ~off:(Int32.to_int offset) ~len in
       let client_memory = Cstruct.of_bigarray (!mapping).client_memory_pool ~off:(Int32.to_int offset) ~len in
       let host_buffer =
         H.Wl_shm_pool.create_buffer (!mapping).host_pool ~offset ~width ~height ~stride ~format
-        @@ H.Wl_buffer.v1 @@ object
+        @@ object
+          inherit [_] H.Wl_buffer.handlers
           method on_release _ = C.Wl_buffer.release buffer
         end 
       in
@@ -248,100 +273,119 @@ let make_output bind c =
   let c = Proxy.cast_version c in
   let h =
     let user_data = host_data (HD.Output c) in
-    bind @@ H.Wl_output.v2 ~user_data @@ object
-      method on_done _ = C.Wl_output.done_ c
+    bind @@ object
+      inherit H.Wl_output.v1
+      method! user_data = user_data
+      method on_done _ = C.Wl_output.done_ (Proxy.cast_version c)
       method on_geometry _ = C.Wl_output.geometry c
       method on_mode _ = C.Wl_output.mode c
-      method on_scale  _ = C.Wl_output.scale c
+      method on_scale  _ = C.Wl_output.scale (Proxy.cast_version c)
     end
   in
-  let _ : _ Proxy.t =
-    let user_data = client_data (Output h) in
-    Proxy.Service_handler.attach c @@ C.Wl_output.v2 ~user_data () in
-  ()
+  let user_data = client_data (Output h) in
+  Proxy.Handler.attach c @@ object
+    inherit [_] C.Wl_output.handlers
+    method! user_data = user_data
+    method on_release = delete_with H.Wl_output.release (cv h)
+  end
 
 let make_seat bind c =
   let c = Proxy.cast_version c in
   let cap_mask = C.Wl_seat.Capability.(Int32.logor keyboard pointer) in
-  let host = bind @@ H.Wl_seat.v5 @@ object
+  let host = bind @@ object
+      inherit H.Wl_seat.v1
+
       method on_capabilities _ ~capabilities =
         C.Wl_seat.capabilities c ~capabilities:(Int32.logand capabilities cap_mask)
-      method on_name _ = C.Wl_seat.name c
+      method on_name _ = C.Wl_seat.name (cv c)
     end
   in
+  let host = cv host in
   let user_data = client_data (Seat host) in
-  let _ : _ Proxy.t = Proxy.Service_handler.attach c @@ C.Wl_seat.v5 ~user_data @@ object
-      method on_get_keyboard _ keyboard =
-        let h : _ Proxy.t = H.Wl_seat.get_keyboard host @@ H.Wl_keyboard.v5 @@ object
-            method on_keymap    _ ~format ~fd ~size =
-              C.Wl_keyboard.keymap keyboard ~format ~fd ~size;
-              Unix.close fd
-            method on_enter     _ ~serial ~surface = C.Wl_keyboard.enter keyboard ~serial ~surface:(to_client surface)
-            method on_leave     _ ~serial ~surface = C.Wl_keyboard.leave keyboard ~serial ~surface:(to_client surface)
-            method on_key       _ = C.Wl_keyboard.key keyboard
-            method on_modifiers _ = C.Wl_keyboard.modifiers keyboard
-            method on_repeat_info _ = C.Wl_keyboard.repeat_info keyboard
-          end
-        in
-        Proxy.Handler.attach keyboard @@ C.Wl_keyboard.v5 @@ object
-          method on_release = delete_with H.Wl_keyboard.release h
+  Proxy.Handler.attach c @@ object
+    inherit [_] C.Wl_seat.handlers
+    method! user_data = user_data
+    method on_get_keyboard _ keyboard =
+      let h : _ Proxy.t = H.Wl_seat.get_keyboard host @@ object
+          inherit [_] H.Wl_keyboard.handlers
+          method on_keymap    _ ~format ~fd ~size =
+            C.Wl_keyboard.keymap keyboard ~format ~fd ~size;
+            Unix.close fd
+          method on_enter     _ ~serial ~surface = C.Wl_keyboard.enter keyboard ~serial ~surface:(to_client surface)
+          method on_leave     _ ~serial ~surface = C.Wl_keyboard.leave keyboard ~serial ~surface:(to_client surface)
+          method on_key       _ = C.Wl_keyboard.key keyboard
+          method on_modifiers _ = C.Wl_keyboard.modifiers keyboard
+          method on_repeat_info _ = C.Wl_keyboard.repeat_info (cv keyboard)
         end
+      in
+      Proxy.Handler.attach keyboard @@ object
+        inherit [_] C.Wl_keyboard.handlers
+        method on_release = delete_with H.Wl_keyboard.release h
+      end
 
-      method on_get_pointer _ c =
-        let h : _ Proxy.t = H.Wl_seat.get_pointer host @@ H.Wl_pointer.v5 @@ object
-            method on_axis _ = C.Wl_pointer.axis c
-            method on_axis_discrete _ = C.Wl_pointer.axis_discrete c
-            method on_axis_source _ = C.Wl_pointer.axis_source c
-            method on_axis_stop _ = C.Wl_pointer.axis_stop c
-            method on_button _ = C.Wl_pointer.button c
-            method on_enter _ ~serial ~surface = C.Wl_pointer.enter c ~serial ~surface:(to_client surface)
-            method on_leave _ ~serial ~surface = C.Wl_pointer.leave c ~serial ~surface:(to_client surface)
-            method on_motion _ = C.Wl_pointer.motion c
-            method on_frame _ = C.Wl_pointer.frame c
-          end
-        in
-        Proxy.Handler.attach c @@ C.Wl_pointer.v5 @@ object
-          method on_set_cursor _ ~serial ~surface = H.Wl_pointer.set_cursor h ~serial ~surface:(Option.map to_host surface)
-          method on_release = delete_with H.Wl_pointer.release h
+    method on_get_pointer _ c =
+      let c = cv c in
+      let h : _ Proxy.t = H.Wl_seat.get_pointer host @@ object
+          inherit [_] H.Wl_pointer.handlers
+          method on_axis _ = C.Wl_pointer.axis c
+          method on_axis_discrete _ = C.Wl_pointer.axis_discrete c
+          method on_axis_source _ = C.Wl_pointer.axis_source c
+          method on_axis_stop _ = C.Wl_pointer.axis_stop c
+          method on_button _ = C.Wl_pointer.button c
+          method on_enter _ ~serial ~surface = C.Wl_pointer.enter c ~serial ~surface:(to_client surface)
+          method on_leave _ ~serial ~surface = C.Wl_pointer.leave c ~serial ~surface:(to_client surface)
+          method on_motion _ = C.Wl_pointer.motion c
+          method on_frame _ = C.Wl_pointer.frame c
         end
+      in
+      Proxy.Handler.attach c @@ object
+        inherit [_] C.Wl_pointer.handlers
+        method on_set_cursor _ ~serial ~surface = H.Wl_pointer.set_cursor h ~serial ~surface:(Option.map to_host surface)
+        method on_release = delete_with H.Wl_pointer.release h
+      end
 
-      method on_get_touch _ = Fmt.failwith "TODO: on_get_touch"
-      method on_release = delete_with H.Wl_seat.release host
-    end
-  in
-  ()
+    method on_get_touch _ = Fmt.failwith "TODO: on_get_touch"
+    method on_release = delete_with H.Wl_seat.release host
+  end
 
 let make_shm ~virtwl bind c =
   let c = Proxy.cast_version c in
-  let h = bind @@ H.Wl_shm.v1 @@ object
+  let h = bind @@ object
+      inherit H.Wl_shm.v1
       method on_format _ = C.Wl_shm.format c
     end
   in
-  let _ : _ Proxy.t = Proxy.Service_handler.attach c @@ C.Wl_shm.v1 @@ object
-      method on_create_pool _ = make_shm_pool ~virtwl ~host_shm:h
-    end
-  in
-  ()
+  Proxy.Handler.attach c @@ object
+    inherit [_] C.Wl_shm.handlers
+    method on_create_pool _ = make_shm_pool ~virtwl ~host_shm:h
+  end
 
 let make_popup ~host_popup c =
-  let h = host_popup @@ H.Xdg_popup.v1 @@ object
+  let h = host_popup @@ object
+      inherit [_] H.Xdg_popup.handlers
       method on_popup_done _ = C.Xdg_popup.popup_done c
       method on_configure _ = C.Xdg_popup.configure c
+      method on_repositioned _ = C.Xdg_popup.repositioned c
     end
   in
-  Proxy.Handler.attach c @@ C.Xdg_popup.v1 @@ object (_ : 'a C.Xdg_popup.h1)
+  Proxy.Handler.attach c @@ object
+    inherit [_] C.Xdg_popup.handlers
     method on_destroy = delete_with H.Xdg_popup.destroy h
     method on_grab _ ~seat = H.Xdg_popup.grab h ~seat:(to_host seat)
+    method on_reposition _ ~positioner = H.Xdg_popup.reposition h ~positioner:(to_host positioner)
   end
 
 let make_toplevel ~tag ~host_toplevel c =
-  let h = host_toplevel @@ H.Xdg_toplevel.v1 @@ object
+  let h = host_toplevel @@ object
+      inherit [_] H.Xdg_toplevel.handlers
       method on_close _ = C.Xdg_toplevel.close c
       method on_configure _ = C.Xdg_toplevel.configure c
     end
   in
   let user_data = client_data (Toplevel h) in
-  Proxy.Handler.attach c @@ C.Xdg_toplevel.v1 ~user_data @@ object (_ : 'a C.Xdg_toplevel.h1)
+  Proxy.Handler.attach c @@ object
+    inherit [_] C.Xdg_toplevel.handlers
+    method! user_data = user_data
     method on_destroy = delete_with H.Xdg_toplevel.destroy h
     method on_move _ ~seat = H.Xdg_toplevel.move h ~seat:(to_host seat)
     method on_resize _ ~seat = H.Xdg_toplevel.resize h ~seat:(to_host seat)
@@ -359,12 +403,16 @@ let make_toplevel ~tag ~host_toplevel c =
   end
 
 let make_xdg_surface ~tag ~host_xdg_surface c =
-  let h = host_xdg_surface @@ H.Xdg_surface.v1 @@ object
+  let c = cv c in
+  let h = host_xdg_surface @@ object
+      inherit [_] H.Xdg_surface.handlers
       method on_configure _ = C.Xdg_surface.configure c
     end
   in
   let user_data = client_data (Xdg_surface h) in
-  Proxy.Handler.attach c @@ C.Xdg_surface.v1 ~user_data @@ object (_ : _ C.Xdg_surface.h1)
+  Proxy.Handler.attach c @@ object
+    inherit [_] C.Xdg_surface.handlers
+    method! user_data = user_data
     method on_destroy = delete_with H.Xdg_surface.destroy h
     method on_ack_configure _ = H.Xdg_surface.ack_configure h
     method on_set_window_geometry _ = H.Xdg_surface.set_window_geometry h
@@ -378,9 +426,11 @@ let make_xdg_surface ~tag ~host_xdg_surface c =
   end
 
 let make_positioner ~host_positioner c =
-  let h = host_positioner @@ H.Xdg_positioner.v1 () in
+  let h = host_positioner @@ new H.Xdg_positioner.handlers in
   let user_data = client_data (Xdg_positioner h) in
-  Proxy.Handler.attach c @@ C.Xdg_positioner.v1 ~user_data @@ object (_ : _ C.Xdg_positioner.h1)
+  Proxy.Handler.attach c @@ object
+    inherit [_] C.Xdg_positioner.handlers
+    method! user_data = user_data
     method on_destroy = delete_with H.Xdg_positioner.destroy h
     method on_set_anchor _ = H.Xdg_positioner.set_anchor h
     method on_set_anchor_rect _ = H.Xdg_positioner.set_anchor_rect h
@@ -388,76 +438,88 @@ let make_positioner ~host_positioner c =
     method on_set_gravity _ = H.Xdg_positioner.set_gravity h
     method on_set_offset _ = H.Xdg_positioner.set_offset h
     method on_set_size _ = H.Xdg_positioner.set_size h
+    method on_set_reactive _ = H.Xdg_positioner.set_reactive h
+    method on_set_parent_size _ = H.Xdg_positioner.set_parent_size h
+    method on_set_parent_configure _ = H.Xdg_positioner.set_parent_configure h
   end
 
 let make_xdg_wm_base ~tag bind proxy =
-  let proxy = Proxy.cast_version proxy in
-  let h = bind @@ H.Xdg_wm_base.v1 @@ object
+  let h = bind @@ object
+      inherit H.Xdg_wm_base.v1
       method on_ping _ = C.Xdg_wm_base.ping proxy
     end
   in
-  let _ : _ Proxy.t = Proxy.Service_handler.attach proxy @@ C.Xdg_wm_base.v1 @@ object (_ : 'a C.Xdg_wm_base.h1)
-      method on_destroy = delete_with H.Xdg_wm_base.destroy h
-      method on_pong _ = H.Xdg_wm_base.pong h
+  let h = Proxy.cast_version h in
+  Proxy.Handler.attach proxy @@ object
+    inherit [_] C.Xdg_wm_base.handlers
 
-      method on_create_positioner _ = make_positioner ~host_positioner:(H.Xdg_wm_base.create_positioner h)
+    method on_destroy = delete_with H.Xdg_wm_base.destroy h
+    method on_pong _ = H.Xdg_wm_base.pong h
 
-      method on_get_xdg_surface _ xdg_surface ~surface =
-        let host_xdg_surface = H.Xdg_wm_base.get_xdg_surface h ~surface:(to_host surface) in
-        make_xdg_surface ~tag ~host_xdg_surface xdg_surface
-    end
-  in
-  ()
+    method on_create_positioner _ = make_positioner ~host_positioner:(H.Xdg_wm_base.create_positioner h)
+
+    method on_get_xdg_surface _ xdg_surface ~surface =
+      let host_xdg_surface = H.Xdg_wm_base.get_xdg_surface h ~surface:(to_host surface) in
+      make_xdg_surface ~tag ~host_xdg_surface xdg_surface
+  end
 
 let make_zxdg_output ~host_xdg_output c =
-  let h = host_xdg_output @@ H.Zxdg_output_v1.v3 @@ object
+  let c = cv c in
+  let h = host_xdg_output @@ object
+      inherit [_] H.Zxdg_output_v1.handlers
       method on_description _ = C.Zxdg_output_v1.description c
       method on_done _ = C.Zxdg_output_v1.done_ c
       method on_logical_position _ = C.Zxdg_output_v1.logical_position c
       method on_logical_size _ = C.Zxdg_output_v1.logical_size c
       method on_name _ = C.Zxdg_output_v1.name c
     end in
-  Proxy.Handler.attach c @@ C.Zxdg_output_v1.v3 @@ object
+  Proxy.Handler.attach c @@ object
+    inherit [_] C.Zxdg_output_v1.handlers
     method on_destroy = delete_with H.Zxdg_output_v1.destroy h
   end
 
 let make_zxdg_output_manager_v1 bind proxy =
   let proxy = Proxy.cast_version proxy in
-  let h = bind @@ H.Zxdg_output_manager_v1.v3 () in
-  let _ : _ Proxy.t = Proxy.Service_handler.attach proxy @@ C.Zxdg_output_manager_v1.v3 @@ object
-      method on_destroy = delete_with H.Zxdg_output_manager_v1.destroy h
+  let h = bind @@ new H.Zxdg_output_manager_v1.v3 in
+  Proxy.Handler.attach proxy @@ object
+    inherit [_] C.Zxdg_output_manager_v1.handlers
 
-      method on_get_xdg_output _ c ~output =
-        let output = to_host output in
-        make_zxdg_output ~host_xdg_output:(H.Zxdg_output_manager_v1.get_xdg_output h ~output) c
-    end
-  in
-  ()
+    method on_destroy = delete_with H.Zxdg_output_manager_v1.destroy h
+
+    method on_get_xdg_output _ c ~output =
+      let output = to_host output in
+      make_zxdg_output ~host_xdg_output:(H.Zxdg_output_manager_v1.get_xdg_output h ~output) c
+  end
 
 let make_data_offer ~virtwl ~client_offer h =
-  let c = client_offer @@ C.Wl_data_offer.v3 @@ object
-    method on_accept _ = H.Wl_data_offer.accept h
-    method on_destroy c =
-      delete_with H.Wl_data_offer.destroy h c;
-      (* Effectively, the "selection" event is the destructor of the previous selection,
-         and this is the confirmation. The server doesn't send a delete event, so just do it manually. *)
-      Proxy.delete h
-    method on_finish _ = H.Wl_data_offer.finish h
-    method on_receive _ ~mime_type ~fd =
-      Pipes.with_wrapped_writeable ~virtwl fd @@ fun fd ->
-      H.Wl_data_offer.receive h ~mime_type ~fd
-    method on_set_actions _ = H.Wl_data_offer.set_actions h
-  end in
+  let c = client_offer @@ object
+      inherit [_] C.Wl_data_offer.handlers
+      method on_accept _ = H.Wl_data_offer.accept h
+      method on_destroy c =
+        delete_with H.Wl_data_offer.destroy h c;
+        (* Effectively, the "selection" event is the destructor of the previous selection,
+           and this is the confirmation. The server doesn't send a delete event, so just do it manually. *)
+        Proxy.delete h
+      method on_finish _ = H.Wl_data_offer.finish h
+      method on_receive _ ~mime_type ~fd =
+        Pipes.with_wrapped_writeable ~virtwl fd @@ fun fd ->
+        H.Wl_data_offer.receive h ~mime_type ~fd
+      method on_set_actions _ = H.Wl_data_offer.set_actions h
+    end in
   let user_data = host_data (HD.Data_offer c) in
-  Proxy.Handler.attach h @@ H.Wl_data_offer.v3 ~user_data @@ object (_ : _ H.Wl_data_offer.h3)
+  Proxy.Handler.attach h @@ object
+    inherit [_] H.Wl_data_offer.handlers
+    method! user_data = user_data
     method on_action _ = C.Wl_data_offer.action c
     method on_offer _ = C.Wl_data_offer.offer c
     method on_source_actions _ = C.Wl_data_offer.source_actions c
   end
 
 let make_data_source ~host_source c =
+  let c = cv c in
   let h =
-    host_source @@ H.Wl_data_source.v3 @@ object (_ : _ H.Wl_data_source.h3)
+    host_source @@ object
+      inherit [_] H.Wl_data_source.handlers
       method on_action _ = C.Wl_data_source.action c
       method on_cancelled _ = C.Wl_data_source.cancelled c
       method on_dnd_drop_performed _ = C.Wl_data_source.dnd_drop_performed c
@@ -468,14 +530,18 @@ let make_data_source ~host_source c =
       method on_target _ = C.Wl_data_source.target c
     end in
   let user_data = client_data (Data_source h) in
-  Proxy.Handler.attach c @@ C.Wl_data_source.v3 ~user_data @@ object (_ : _ C.Wl_data_source.h3)
-      method on_destroy = delete_with H.Wl_data_source.destroy h
-      method on_offer _ = H.Wl_data_source.offer h
-      method on_set_actions _ = H.Wl_data_source.set_actions h
+  Proxy.Handler.attach c @@ object
+    inherit [_] C.Wl_data_source.handlers
+    method! user_data = user_data
+    method on_destroy = delete_with H.Wl_data_source.destroy h
+    method on_offer _ = H.Wl_data_source.offer h
+    method on_set_actions _ = H.Wl_data_source.set_actions h
   end
 
 let make_data_device ~virtwl ~host_device c =
-  let h = host_device @@ H.Wl_data_device.v3 @@ object (_ : _ H.Wl_data_device.h2)
+  let c = cv c in
+  let h = host_device @@ object
+      inherit [_] H.Wl_data_device.handlers
       method on_data_offer _ offer = make_data_offer ~virtwl ~client_offer:(C.Wl_data_device.data_offer c) offer
       method on_drop _ = C.Wl_data_device.drop c
       method on_enter _ ~serial ~surface ~x ~y offer =
@@ -484,7 +550,8 @@ let make_data_device ~virtwl ~host_device c =
       method on_motion _ = C.Wl_data_device.motion c
       method on_selection _ offer = C.Wl_data_device.selection c (Option.map to_client offer)
     end in
-  Proxy.Handler.attach c @@ C.Wl_data_device.v3 @@ object (_ : _ C.Wl_data_device.h2)
+  Proxy.Handler.attach c @@ object
+    inherit [_] C.Wl_data_device.handlers
     method on_release = delete_with H.Wl_data_device.release h
     method on_set_selection _ ~source = H.Wl_data_device.set_selection h ~source:(Option.map to_host source)
     method on_start_drag _ ~source ~origin ~icon =
@@ -496,54 +563,62 @@ let make_data_device ~virtwl ~host_device c =
 
 let make_data_device_manager ~virtwl bind proxy =
   let proxy = Proxy.cast_version proxy in
-  let h = bind @@ H.Wl_data_device_manager.v3 () in
-  let _ : _ Proxy.t = Proxy.Service_handler.attach proxy @@ C.Wl_data_device_manager.v3 @@ object
-      method on_create_data_source _ c =
-        make_data_source c ~host_source:(H.Wl_data_device_manager.create_data_source h)
-      method on_get_data_device _ c ~seat =
-        let seat = to_host seat in
-        make_data_device ~virtwl c ~host_device:(H.Wl_data_device_manager.get_data_device h ~seat)
-    end
-  in
-  ()
+  let h = bind @@ new H.Wl_data_device_manager.v3 in
+  Proxy.Handler.attach proxy @@ object
+    inherit [_] C.Wl_data_device_manager.handlers
+    method on_create_data_source _ c =
+      make_data_source c ~host_source:(H.Wl_data_device_manager.create_data_source h)
+    method on_get_data_device _ c ~seat =
+      let seat = to_host seat in
+      make_data_device ~virtwl c ~host_device:(H.Wl_data_device_manager.get_data_device h ~seat)
+  end
 
 let make_gtk_data_offer ~virtwl ~client_offer h =
-  let c = client_offer @@ C.Gtk_primary_selection_offer.v1 @@ object (_ : _ C.Gtk_primary_selection_offer.h1)
-    method on_destroy c =
-      delete_with H.Gtk_primary_selection_offer.destroy h c;
-      (* Effectively, the "selection" event is the destructor of the previous selection,
-         and this is the confirmation. The server doesn't send a delete event, so just do it manually. *)
-      Proxy.delete h
+  let c = client_offer @@ object
+      inherit [_] C.Gtk_primary_selection_offer.handlers
 
-    method on_receive _ ~mime_type ~fd =
-      Pipes.with_wrapped_writeable ~virtwl fd @@ fun fd ->
-      H.Gtk_primary_selection_offer.receive h ~mime_type ~fd
-  end in
+      method on_destroy c =
+        delete_with H.Gtk_primary_selection_offer.destroy h c;
+        (* Effectively, the "selection" event is the destructor of the previous selection,
+           and this is the confirmation. The server doesn't send a delete event, so just do it manually. *)
+        Proxy.delete h
+
+      method on_receive _ ~mime_type ~fd =
+        Pipes.with_wrapped_writeable ~virtwl fd @@ fun fd ->
+        H.Gtk_primary_selection_offer.receive h ~mime_type ~fd
+    end in
   let user_data = host_data (HD.Gtk_data_offer c) in
-  Proxy.Handler.attach h @@ H.Gtk_primary_selection_offer.v1 ~user_data @@ object
+  Proxy.Handler.attach h @@ object
+    inherit [_] H.Gtk_primary_selection_offer.handlers
+    method! user_data = user_data
     method on_offer _ = C.Gtk_primary_selection_offer.offer c
   end
 
 let make_gtk_primary_selection_source ~host_source c =
   let h =
-    host_source @@ H.Gtk_primary_selection_source.v1 @@ object
+    host_source @@ object
+      inherit [_] H.Gtk_primary_selection_source.handlers
       method on_cancelled _ = C.Gtk_primary_selection_source.cancelled c
       method on_send _ ~mime_type ~fd =
         C.Gtk_primary_selection_source.send c ~mime_type ~fd;
         Unix.close fd
     end in
   let user_data = client_data (Gtk_source h) in
-  Proxy.Handler.attach c @@ C.Gtk_primary_selection_source.v1 ~user_data @@ object
-      method on_destroy = delete_with H.Gtk_primary_selection_source.destroy h
-      method on_offer _ = H.Gtk_primary_selection_source.offer h
+  Proxy.Handler.attach c @@ object
+    inherit [_] C.Gtk_primary_selection_source.handlers
+    method! user_data = user_data
+    method on_destroy = delete_with H.Gtk_primary_selection_source.destroy h
+    method on_offer _ = H.Gtk_primary_selection_source.offer h
   end
 
 let make_gtk_primary_selection_device ~virtwl ~host_device c =
-  let h = host_device @@ H.Gtk_primary_selection_device.v1 @@ object (_ : _ H.Gtk_primary_selection_device.h1)
+  let h = host_device @@ object
+      inherit [_] H.Gtk_primary_selection_device.handlers
       method on_data_offer _ offer = make_gtk_data_offer ~virtwl ~client_offer:(C.Gtk_primary_selection_device.data_offer c) offer
       method on_selection _ offer = C.Gtk_primary_selection_device.selection c (Option.map to_client offer)
     end in
-  Proxy.Handler.attach c @@ C.Gtk_primary_selection_device.v1 @@ object
+  Proxy.Handler.attach c @@ object
+    inherit [_] C.Gtk_primary_selection_device.handlers
     method on_destroy = delete_with H.Gtk_primary_selection_device.destroy h
     method on_set_selection _ ~source =
       let source = Option.map to_host source in
@@ -552,19 +627,18 @@ let make_gtk_primary_selection_device ~virtwl ~host_device c =
 
 let make_gtk_primary_selection_device_manager ~virtwl bind proxy =
   let proxy = Proxy.cast_version proxy in
-  let h = bind @@ H.Gtk_primary_selection_device_manager.v1 () in
-  let _ : _ Proxy.t = Proxy.Service_handler.attach proxy @@ C.Gtk_primary_selection_device_manager.v1 @@ object
-      method on_create_source _ source =
-        let host_source = H.Gtk_primary_selection_device_manager.create_source h in
-        make_gtk_primary_selection_source ~host_source source
-      method on_destroy = delete_with H.Gtk_primary_selection_device_manager.destroy h
-      method on_get_device _ dev ~seat =
-        let seat = to_host seat in
-        let host_device = H.Gtk_primary_selection_device_manager.get_device h ~seat in
-        make_gtk_primary_selection_device ~virtwl ~host_device dev
-    end
-  in
-  ()
+  let h = bind @@ new H.Gtk_primary_selection_device_manager.v1 in
+  Proxy.Handler.attach proxy @@ object
+    inherit [_] C.Gtk_primary_selection_device_manager.handlers
+    method on_create_source _ source =
+      let host_source = H.Gtk_primary_selection_device_manager.create_source h in
+      make_gtk_primary_selection_source ~host_source source
+    method on_destroy = delete_with H.Gtk_primary_selection_device_manager.destroy h
+    method on_get_device _ dev ~seat =
+      let seat = to_host seat in
+      let host_device = H.Gtk_primary_selection_device_manager.get_device h ~seat in
+      make_gtk_primary_selection_device ~virtwl ~host_device dev
+  end
 
 type entry = Entry : int * (module Metadata.S) -> entry
 
@@ -579,8 +653,8 @@ let registry =
   let open Wayland_protocols.Xdg_shell_proto in
   let open Wayland_protocols.Xdg_output_unstable_v1_proto in
   let open Wayland_protocols.Gtk_primary_selection_proto in
-  Array.of_list [
-    entry ~max_version:3 (module Wl_compositor);
+  [
+    entry ~max_version:4 (module Wl_compositor);
     entry ~max_version:1 (module Wl_subcompositor);
     entry ~max_version:1 (module Wl_shm);
     entry ~max_version:1 (module Xdg_wm_base);
@@ -592,25 +666,41 @@ let registry =
   ]
 
 let make_registry t reg =
-  Proxy.Handler.attach reg @@ C.Wl_registry.v1 @@ object
+  let registry =
+    registry |> List.filter_map (fun entry ->
+        let Entry (our_max_version, (module M)) = entry in
+        match Registry.get t.host_registry M.interface with
+        | [] ->
+          Log.info (fun f -> f "Host doesn't support service %s, so skipping" M.interface);
+          None
+        | { Registry.name; version = host_version } :: _ ->
+          let max_version = min our_max_version (Int32.to_int host_version) in
+          Some (name, Entry (max_version, (module M)))
+      )
+    |> Array.of_list
+  in
+  Proxy.Handler.attach reg @@ object
+    inherit [_] C.Wl_registry.handlers
+
     method on_bind : type a. _ -> name:int32 -> (a, [`Unknown], _) Proxy.t -> unit =
       fun _ ~name proxy ->
       let name = Int32.to_int name in
       if name < 0 || name >= Array.length registry then Fmt.failwith "Bad registry entry name %d" name;
-      let Entry (max_version, (module M)) = registry.(name) in
+      let host_name, Entry (max_version, (module M)) = registry.(name) in
       let requested_version = Int32.to_int (Proxy.version proxy) in
       if requested_version > max_version then
         Fmt.failwith "Client asked for %S v%d, but we only support up to %d" M.interface requested_version max_version;
       let client_interface = Proxy.interface proxy in
       if client_interface <> M.interface then
         Fmt.failwith "Entry %d has type %S, client expected %S!" name M.interface client_interface;
-      let bind x = Wayland.Registry.bind t.host_registry x in
+      let bind x = H.Wl_registry.bind (Registry.wl_registry t.host_registry) ~name:host_name (x, Proxy.version proxy) in
       let open Wayland_proto in
       let open Wayland_protocols.Xdg_shell_proto in
       let open Wayland_protocols.Xdg_output_unstable_v1_proto in
       let open Wayland_protocols.Gtk_primary_selection_proto in
+      let proxy = Proxy.cast_version proxy in
       match Proxy.ty proxy with
-      | Wl_compositor.T -> make_compositor t bind proxy
+      | Wl_compositor.T -> make_compositor bind proxy
       | Wl_subcompositor.T -> make_subcompositor bind proxy
       | Wl_shm.T -> make_shm ~virtwl:t.virtwl bind proxy
       | Wl_seat.T -> make_seat bind proxy
@@ -621,9 +711,9 @@ let make_registry t reg =
       | Zxdg_output_manager_v1.T -> make_zxdg_output_manager_v1 bind proxy
       | _ -> Fmt.failwith "Invalid service name for %a" Proxy.pp proxy
   end;
-  registry |> Array.iteri (fun i entry ->
-      let Entry (max_version, (module M)) = entry in
-      C.Wl_registry.global reg ~name:(Int32.of_int i) ~interface:M.interface ~version:(Int32.of_int max_version)
+  registry |> Array.iteri (fun name (_, entry) ->
+      let Entry (version, (module M)) = entry in
+      C.Wl_registry.global reg ~name:(Int32.of_int name) ~interface:M.interface ~version:(Int32.of_int version)
     )
 
 let handle ~config client =
@@ -639,11 +729,13 @@ let handle ~config client =
     config;
   } in
   let s : Server.t =
-    Server.connect client_transport ~trace:(module Trace.Client) @@ C.Wl_display.v1 @@ object
+    Server.connect client_transport ~trace:(module Trace.Client) @@ object
+      inherit [_] C.Wl_display.handlers
       method on_get_registry _ ref = make_registry t ref
       method on_sync _ cb =
-        Proxy.Handler.attach cb @@ C.Wl_callback.v1 ();
-        let h : _ Proxy.t = H.Wl_display.sync (Display.wl_display display) @@ H.Wl_callback.v1 @@ object
+        Proxy.Handler.attach cb @@ new C.Wl_callback.handlers;
+        let h : _ Proxy.t = H.Wl_display.sync (Display.wl_display display) @@ object
+            inherit [_] H.Wl_callback.handlers
             method on_done ~callback_data =
               C.Wl_callback.done_ cb ~callback_data
           end

--- a/tests/test.ml
+++ b/tests/test.ml
@@ -25,7 +25,7 @@ let draw_frame t =
   let stride = t.width * 4 in
   let size = t.height * stride in
   let pool, data = with_memory_fd t.virtwl ~size (fun fd ->
-      let pool = Wl_shm.create_pool t.shm (Wl_shm_pool.v1 ()) ~fd ~size:(Int32.of_int size) in
+      let pool = Wl_shm.create_pool t.shm (new Wl_shm_pool.handlers) ~fd ~size:(Int32.of_int size) in
       let ba = Wayland_virtwl.map_file fd Bigarray.Int32 ~n_elements:(t.height * t.width) in
       pool, Bigarray.reshape_2 ba t.height t.width
     ) in
@@ -36,7 +36,8 @@ let draw_frame t =
       ~height:(Int32.of_int t.height)
       ~stride:(Int32.of_int stride)
       ~format:Wl_shm.Format.Xrgb8888
-    @@ Wl_buffer.v1 @@ object
+    @@ object
+      inherit [_] Wl_buffer.handlers
       method on_release = Wl_buffer.destroy
     end
   in
@@ -67,36 +68,45 @@ let () =
         | Error ex -> raise ex
       );
     let* r = Wayland.Registry.of_display display in
-    let comp = Wayland.Registry.bind r @@ Wl_compositor.v4 () in
-    let xdg_wm_base = Wayland.Registry.bind r @@ Xdg_wm_base.v1 @@ object
+    let comp = Wayland.Registry.bind r @@ new Wl_compositor.v4 in
+    let xdg_wm_base = Wayland.Registry.bind r @@ object
+        inherit Xdg_wm_base.v1
         method on_ping = Xdg_wm_base.pong
       end in
-    let shm = Wayland.Registry.bind r @@ Wl_shm.v1 @@ object
+    let shm = Wayland.Registry.bind r @@ object
+        inherit Wl_shm.v1
         method on_format _ ~format:_ = ()
       end in
-    let seat = Wayland.Registry.bind r @@ Wl_seat.v1 @@ object
+    let seat = Wayland.Registry.bind r @@ object
+        inherit Wl_seat.v1
         method on_capabilities _ ~capabilities:_ = ()
+        method on_name _ ~name:_ = ()
       end in
-    let _keyboard = Wl_seat.get_keyboard seat @@ Wl_keyboard.v1 @@ object
+    let _keyboard = Wl_seat.get_keyboard seat @@ object
+        inherit [_] Wl_keyboard.handlers
         method on_enter _ ~serial:_ ~surface:_ ~keys:_ = ()
         method on_key _ ~serial:_ ~time:_ ~key:_ ~state:_ = ()
         method on_keymap _ ~format:_ ~fd ~size:_ = Unix.close fd
         method on_leave _ ~serial:_ ~surface:_ = ()
         method on_modifiers _ ~serial:_ ~mods_depressed:_ ~mods_latched:_ ~mods_locked:_ ~group:_ = ()
+        method on_repeat_info _ ~rate:_ ~delay:_ = ()
       end in
-    let surface = Wl_compositor.create_surface comp @@ Wl_surface.v4 @@ object
+    let surface = Wl_compositor.create_surface comp @@ object
+        inherit [_] Wl_surface.handlers
         method on_enter _ ~output:_ = ()
         method on_leave _ ~output:_ = ()
       end in
     let t = { virtwl; shm; surface; scroll = 0; width = 0; height = 0; fg = 0xFFEEEEEEl } in
     let closed, set_closed = Lwt.wait () in
     let configured, set_configured = Lwt.wait () in
-    let xdg_surface = Xdg_wm_base.get_xdg_surface xdg_wm_base ~surface @@ Xdg_surface.v1 @@ object
+    let xdg_surface = Xdg_wm_base.get_xdg_surface xdg_wm_base ~surface @@ object
+        inherit [_] Xdg_surface.handlers
         method on_configure p ~serial =
           Xdg_surface.ack_configure p ~serial;
           if Lwt.is_sleeping configured then Lwt.wakeup set_configured ()
     end in
-    let toplevel = Xdg_surface.get_toplevel xdg_surface @@ Xdg_toplevel.v1 @@ object
+    let toplevel = Xdg_surface.get_toplevel xdg_surface @@ object
+        inherit [_] Xdg_toplevel.handlers
         method on_close _ = Lwt.wakeup set_closed ()
         method on_configure _ ~width ~height ~states:_ =
           t.width <- if width = 0l then 640 else Int32.to_int width;

--- a/virtwl_proxy.ml
+++ b/virtwl_proxy.ml
@@ -1,7 +1,5 @@
 open Lwt.Syntax
 
-let socket_path = "/run/user/1000/wayland-1"
-
 let rec listen ~config socket =
   let* (client, _addr) = Lwt_unix.accept socket in
   Log.info (fun f -> f "New connection");
@@ -13,20 +11,40 @@ let () =
   (* Logs.(set_level (Some Info)); *)
   Printexc.record_backtrace true
 
-let main tag args =
+let is_listening path =
+  let s = Unix.(socket PF_UNIX SOCK_STREAM 0) in
+  Fun.protect ~finally:(fun () -> Unix.close s) @@ fun () ->
+  match Unix.connect s (Unix.ADDR_UNIX path) with
+  | () -> true
+  | exception Unix.Unix_error(Unix.ECONNREFUSED, _, _) -> false
+  | exception ex ->
+    Log.warn (fun f -> f "Error testing socket %S: %a" path Fmt.exn ex);
+    false
+
+let main tag wayland_display args =
   let config = { Config.tag } in
-  Lwt_main.run begin
-    let listening_socket = Unix.(socket PF_UNIX SOCK_STREAM 0) in
-    if Sys.file_exists socket_path then Unix.unlink socket_path;
-    Unix.bind listening_socket (Unix.ADDR_UNIX socket_path);
-    Unix.listen listening_socket 5;
-    Log.info (fun f -> f "Listening on %S" socket_path);
-    Lwt.async (fun () -> listen ~config (Lwt_unix.of_unix_file_descr listening_socket));
-    Unix.putenv "WAYLAND_DISPLAY" socket_path;
-    let child = Lwt_process.open_process ("", Array.of_list args) in
-    let* _ = child#status in
-    Lwt.return ()
-  end
+  let socket_path = Wayland.Unix_transport.socket_path ~wayland_display () in
+  let existing_socket = Sys.file_exists socket_path in
+  if existing_socket && is_listening socket_path then (
+   `Error (false, Fmt.strf "A server is already listening on %S!" socket_path)
+  ) else (
+    if existing_socket then Unix.unlink socket_path;
+    Lwt_main.run begin
+      let listening_socket = Unix.(socket PF_UNIX SOCK_STREAM 0) in
+      Unix.bind listening_socket (Unix.ADDR_UNIX socket_path);
+      Unix.listen listening_socket 5;
+      Log.info (fun f -> f "Listening on %S" socket_path);
+      Lwt.async (fun () -> listen ~config (Lwt_unix.of_unix_file_descr listening_socket));
+      Unix.putenv "WAYLAND_DISPLAY" wayland_display;
+      match args with
+      | [] ->
+        fst (Lwt.wait ())
+      | args ->
+        let child = Lwt_process.open_process ("", Array.of_list args) in
+        let* _ = child#status in
+        Lwt.return (`Ok ())
+    end
+  )
 
 open Cmdliner
 
@@ -37,14 +55,21 @@ let tag =
     ~doc:"Tag to prefix to window titles"
     ["tag"]
 
+let wayland_display =
+  Arg.value @@
+  Arg.(opt string) "wayland-1" @@
+  Arg.info
+    ~doc:"Name or path of socket to listen on"
+    ["wayland-display"]
+
 let args =
   Arg.value @@
-  Arg.(pos_all string) ["evince"] @@
+  Arg.(pos_all string) [] @@
   Arg.info
     ~doc:"Sub-command to execute"
     []
 
-let virtwl_proxy = Term.(const main $ tag $ args)
+let virtwl_proxy = Term.(ret (const main $ tag $ wayland_display $ args))
 
 let term_exit (x : unit Term.result) = Term.exit x
 

--- a/virtwl_proxy.ml
+++ b/virtwl_proxy.ml
@@ -10,7 +10,7 @@ let rec listen ~config socket =
 
 let () =
   Logs.set_reporter (Logs_fmt.reporter ());
-  Logs.(set_level (Some Info));
+  (* Logs.(set_level (Some Info)); *)
   Printexc.record_backtrace true
 
 let main tag args =


### PR DESCRIPTION
Before, the client had to ask for the exact versions we offered. Now, any previous version is fine too. This is especially necessary for Firefox, which opens multiple connections using different service versions!

Also, added `--wayland-display` argument to choose where to listen.

With this, the proxy is quite usable (I'm using it now to submit this PR with Firefox).